### PR TITLE
Packaging and misc. changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packaging/output/

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ all:
 
 deb:
 	mkdir -p packaging/output
-	fpm -s dir -t deb -n suricata-service -v ${VERSION} -p packaging/output/suricata-service.deb -a all \
-		--category admin --force --deb-compression bzip2 --description "Suricata service script" --license "GPL v2" \
+	fpm -s dir -t deb -n suricata-service -v ${VERSION} \
+		-p packaging/output/suricata-service.deb -a all \
+		--category admin --force --deb-compression bzip2 \
+		--description "Suricata service script" --license "GPL v2" \
+		--depends libcap2-bin \
 		--after-install packaging/scripts/postinst.sh root/=/
 
 clean:

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
-useradd --system --create-home --home-dir /opt/suricata suricata
+mkdir -p /opt/suricata
+adduser \
+--quiet \
+--system \
+--no-create-home \
+--group \
+--disabled-password \
+--home /opt/suricata \
+suricata
+
 mkdir -p /opt/suricata/logs
 cp /etc/nsm/templates/suricata/* /opt/suricata
 chown -R suricata /opt/suricata

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -1,19 +1,26 @@
 #!/bin/sh
-mkdir -p /opt/suricata
+BINARY_PATH=/usr/bin/suricata
+SURICATA_DIR=/opt/suricata
+
+# Create a suricata system user and group with the given home directory
+mkdir -p $SURICATA_DIR
+
 adduser \
 --quiet \
 --system \
 --no-create-home \
 --group \
 --disabled-password \
---home /opt/suricata \
+--home $SURICATA_DIR \
 suricata
 
-mkdir -p /opt/suricata/logs
-cp /etc/nsm/templates/suricata/* /opt/suricata
-chown -R suricata /opt/suricata
+# Create locations for rules, logs, and templates
+mkdir -p $SURICATA_DIR/rules
+mkdir -p $SURICATA_DIR/logs
+cp /etc/nsm/templates/suricata/*.config $SURICATA_DIR
 
-SURICATA=/usr/bin/suricata
-chown suricata $SURICATA
-chmod 750 $SURICATA
-setcap cap_net_raw,cap_net_admin=eip $SURICATA
+# Set permissions
+chown -R suricata:suricata $SURICATA_DIR
+chown suricata:suricata $BINARY_PATH
+chmod 750 $BINARY_PATH
+setcap cap_net_raw,cap_net_admin=eip $BINARY_PATH

--- a/root/opt/suricata/suricata.yaml
+++ b/root/opt/suricata/suricata.yaml
@@ -462,7 +462,7 @@ pcap-file:
 
 # Set the default rule path here to search for the files.
 # if not set, it will look at the current working dir
-default-rule-path: /etc/nsm/rules/
+default-rule-path: /opt/suricata/rules/
 rule-files:
  - local.rules
  - downloaded.rules


### PR DESCRIPTION
A few changes:
- A `.gitignore` file that prevents the .deb file from being indexed by git
- Explicit dependency on `libcap2-bin` for the `setcap` utility
- Changes `suricata.yaml` to point at `/opt/suricata/rules` instead of `/etc/nsm/rules`
- Makes the `suricata` user a system user
