### PR TITLE
Recommend Observable Networks ona-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ deb:
 		--category admin --force --deb-compression bzip2 \
 		--description "Suricata service script" --license "GPL v2" \
 		--depends libcap2-bin \
+		--depends sysvinit-utils \
+		--deb-recommends ona-service \
 		--after-install packaging/scripts/postinst.sh root/=/
 
 clean:

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -29,6 +29,6 @@ cp /etc/nsm/templates/suricata/*.config $SURICATA_DIR
 chown -R suricata:suricata $SURICATA_DIR
 chown suricata:suricata $BINARY_PATH
 chmod 0750 $BINARY_PATH
-chmod 0750 $ SURICATA_DIR/logcycle.sh
+chmod 0750 $SURICATA_DIR/logcycle.sh
 chmod g+w $SURICATA_DIR/logs
 setcap cap_net_raw,cap_net_admin=eip $BINARY_PATH

--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -x
+
 BINARY_PATH=/usr/bin/suricata
 SURICATA_DIR=/opt/suricata
 
@@ -6,13 +8,17 @@ SURICATA_DIR=/opt/suricata
 mkdir -p $SURICATA_DIR
 
 adduser \
---quiet \
---system \
---no-create-home \
---group \
---disabled-password \
---home $SURICATA_DIR \
-suricata
+    --quiet \
+    --system \
+    --no-create-home \
+    --group \
+    --disabled-password \
+    --home $SURICATA_DIR \
+    suricata
+
+# If the ona-service package (recommended) is installed, add the obsrvbl_ona
+# user to the suricata group so it can read alert logs.
+addgroup obsrvbl_ona suricata
 
 # Create locations for rules, logs, and templates
 mkdir -p $SURICATA_DIR/rules
@@ -22,5 +28,7 @@ cp /etc/nsm/templates/suricata/*.config $SURICATA_DIR
 # Set permissions
 chown -R suricata:suricata $SURICATA_DIR
 chown suricata:suricata $BINARY_PATH
-chmod 750 $BINARY_PATH
+chmod 0750 $BINARY_PATH
+chmod 0750 $ SURICATA_DIR/logcycle.sh
+chmod g+w $SURICATA_DIR/logs
 setcap cap_net_raw,cap_net_admin=eip $BINARY_PATH

--- a/root/etc/init/suricata.conf
+++ b/root/etc/init/suricata.conf
@@ -1,10 +1,10 @@
 start on (filesystem and net-device-up IFACE!=lo)
 
 setuid suricata
-setgid nogroup
+setgid suricata
 
-chdir /opt/suricata
 console log
 
 respawn
-exec suricata -c suricata.yaml --af-packet
+
+exec /usr/bin/suricata -c /opt/suricata/suricata.yaml --af-packet

--- a/root/etc/init/suricata.conf
+++ b/root/etc/init/suricata.conf
@@ -6,5 +6,5 @@ setgid suricata
 console log
 
 respawn
-
+chdir /opt/suricata
 exec /usr/bin/suricata -c /opt/suricata/suricata.yaml --af-packet

--- a/root/opt/suricata/logcycle.sh
+++ b/root/opt/suricata/logcycle.sh
@@ -1,18 +1,25 @@
-#!/bin/bash
+#!/bin/sh
 
-# run every ten minutes.
-
+LOG_FILE=/opt/suricata/logs/eve.json
 DATE=$(date +%s)
-PID=$(ps ax | grep "suricata -c suricata.yaml" | grep -v grep | awk '{print $1}')
+PID=$(pidof "/usr/bin/suricata")
 
-cd logs
-mv eve.json eve.json.$DATE
+# Exit early if the log file doesn't exist
+if [ ! -e $LOG_FILE ]
+then
+    echo "$LOG_FILE does not exist"
+    exit 0
+fi
 
-# sending a HUP to suricata tells it to re-open its log files
+# Also exit early if the log file is 0 bytes
+if [ ! -s $LOG_FILE ]
+then
+    echo "$LOG_FILE is 0 bytes"
+    exit 0
+fi
+
+
+# Rename the current log file and then send suricata a HUP signal to tell it
+# to open a new log file.
+mv $LOG_FILE $LOG_FILE.$DATE.archived
 /bin/kill -HUP $PID
-
-# TODO:
-# do something with the eve.json.$DATE file
-
-rm eve.json.$DATE
-


### PR DESCRIPTION
The changes in this PR facilitate integration with the Observable Networks `ona-service` package. Specifically:
- The .deb package now `Recommends` the `ona-service` package.
- The post-install script now adds the `obsrvbl_ona` user to the `suricata` group. This allows that user to read Suricata's alert log files.
- The `logcycle.sh` script is changed to no longer remove the archived logs immediately.
