### PR TITLE
Update Suricata to 3.2.1

### DIFF
--- a/packaging/scripts/postinst.sh
+++ b/packaging/scripts/postinst.sh
@@ -39,20 +39,13 @@ fi
 # Update library paths
 ldconfig
 
-# Install the Upstart service
-# systemd (RHEL style)
-if [ -d /usr/lib/systemd/system ] && [ -e /usr/bin/systemctl ]; then
-    cp $SURICATA_DIR/system/suricata.service /usr/lib/systemd/system
-    ln -s /usr/lib/systemd/system/suricata.service /etc/systemd/system/suricata.service
-    /usr/bin/systemctl daemon-reload
-    /usr/bin/systemctl start suricata.service
-# systemd (Debian style)
-elif [ -d /lib/systemd/system ] && [ -e /bin/systemctl ]; then
-    cp $SURICATA_DIR/system/suricata.service /lib/systemd/system
-    ln -s /lib/systemd/system/suricata.service /etc/systemd/system/suricata.service
+# Install the systemd service
+if [ -e /bin/systemctl ]; then
+    cp $SURICATA_DIR/system/suricata.service /etc/systemd/system/suricata.service
     /bin/systemctl daemon-reload
+    /bin/systemctl enable suricata.service
     /bin/systemctl start suricata.service
-# upstart
+# Install the upstart service
 else
     cp $SURICATA_DIR/system/suricata.conf /etc/init/
     initctl reload-configuration


### PR DESCRIPTION
This PR updates Suricata to 3.2.1 - see the [upstream changelog](https://github.com/inliniac/suricata/commit/e072a10f64cd509d09e0349050b92b02fea4df9c) for details.