### PR TITLE
Drone1.x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ pipeline:
   submodules:
     image: docker:git
     commands:
-      - git submodule update --recursive --remote
+      - git submodule update --init --recursive
 
   build:
     image: obsrvbl/docker-images:suricata-${SURICATA_IMAGE}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,9 @@
 pipeline:
+  clone:
+    image: docker:git
+    commands:
+      - git submodule update --recursive --remote
+
   build:
     image: obsrvbl/docker-images:suricata-${SURICATA_IMAGE}
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 pipeline:
-  clone:
+  submodules:
     image: docker:git
     commands:
       - git submodule update --recursive --remote


### PR DESCRIPTION
Turns out drone 1.x is backwards compatible with the matrix style syntax we use. It might not be optimal here but it is simple. There is a [new option to construct builds for this](https://discourse.drone.io/t/porting-matrix-builds-to-1-0-multi-machine-pipelines/2966), but it adds a layer of indirection which I don't want to deal with right now.

The only difference here is that 1.x doesn't do a recursive clone by default.